### PR TITLE
Rename custom evaluator in the example

### DIFF
--- a/examples/custom_evaluator.py
+++ b/examples/custom_evaluator.py
@@ -2,14 +2,14 @@ from root import RootSignals
 
 client = RootSignals()
 
-direct_language_evaluator = client.evaluators.create(
-    name="Direct language",
+direct_communication_evaluator = client.evaluators.create(
+    name="Direct communication",
     predicate="Is the following text clear and has no weasel words: {{response}}",
     intent="Is the language direct and unambiguous",
     model="gpt-4o",
 )
 
-response = direct_language_evaluator.run(response="It will probably rain tomorrow.")
+response = direct_communication_evaluator.run(response="It will probably rain tomorrow.")
 
 print(response.score)
 print(response.justification)


### PR DESCRIPTION
Since evaluator names should be unique and we have two examples using similar evaluators, it is better for them to have different names.