### PR TITLE
Fix example showing how to tag evaluator runs

### DIFF
--- a/examples/run_tagging.py
+++ b/examples/run_tagging.py
@@ -10,7 +10,7 @@ result = client.evaluators.Clarity(
 )
 
 # Get the execution log for the evaluator run.
-log = client.execution_logs.get(result)
+log = client.execution_logs.get(execution_result=result)
 print(log)
 
 


### PR DESCRIPTION
Must use a named parameter for the execution result.