### PR TITLE
Include optional fields to execution logs

### DIFF
--- a/examples/run_tagging.py
+++ b/examples/run_tagging.py
@@ -4,8 +4,18 @@ from root import RootSignals
 client = RootSignals()
 
 # Run an evaluator with tags to track the execution.
-result = client.evaluators.Clarity(
-    response="Sure, let me help you to fix your issue with your network connection. Start by...",
+result = client.evaluators.Faithfulness(
+    request="What is your return policy for electronics?",
+    response="""
+    You can return electronics within 30 days of purchase, provided the item is unused and in its original packaging.
+    A receipt or proof of purchase is required.",
+    """,
+    contexts=[
+        """Our returns policy for electronics allows returns within 30 days of purchase.
+        The item must be unused, in its original packaging, and accompanied by a valid receipt or proof of purchase.
+        Refunds will be issued to the original payment method.""",
+        """A receipt or proof of purchase is required.""",
+    ],
     tags=["production", "v1.23"],
 )
 
@@ -15,6 +25,8 @@ print(log)
 
 
 # And get all the logs with the same tags.
-logs = client.execution_logs.list(tags=["production"])
+# Also include the evaluation context field in the response which by default is not included.
+logs = client.execution_logs.list(tags=["production"], include=["evaluation_context"])
 for log in logs:
     print(log.score)
+    print(log.evaluation_context.contexts)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -993,6 +993,7 @@ paths:
         name: id
         schema:
           type: string
+          format: uuid
         required: true
       tags:
       - v1
@@ -1150,6 +1151,13 @@ paths:
         description: The pagination cursor value.
         schema:
           type: string
+      - in: query
+        name: include
+        schema:
+          type: string
+          default: ''
+        description: 'Comma-separated list of additional fields to include in the
+          response. Supports: llm_output, variables, evaluation_context'
       - name: ordering
         required: false
         in: query
@@ -2028,13 +2036,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/Skill'
           description: ''
-  /v1/skills/evaluator/execute/{skill_id}/:
+  /v1/skills/evaluator/execute/{id}/:
     post:
       operationId: v1_skills_evaluator_execute_create
       description: Execute an evaluator
       parameters:
       - in: path
-        name: skill_id
+        name: id
         schema:
           type: string
           format: uuid
@@ -3357,6 +3365,16 @@ components:
           format: date-time
           readOnly: true
           nullable: true
+        evaluation_context:
+          type: object
+          properties:
+            contexts:
+              type: array
+              items:
+                type: string
+            expected_output:
+              type: string
+          readOnly: true
         id:
           type: string
           format: uuid
@@ -3397,6 +3415,10 @@ components:
           allOf:
           - $ref: '#/components/schemas/NestedUserDetails'
           readOnly: true
+        parent_execution_log_id:
+          type: string
+          format: uuid
+          nullable: true
         rendered_prompt:
           type: string
           readOnly: true
@@ -3440,11 +3462,16 @@ components:
             $ref: '#/components/schemas/SkillExecutionValidatorResult'
           readOnly: true
         variables:
+          type: object
+          additionalProperties:
+            type: string
           readOnly: true
+          nullable: true
       required:
       - chat_id
       - cost
       - created_at
+      - evaluation_context
       - id
       - judge
       - justification
@@ -3487,6 +3514,10 @@ components:
           allOf:
           - $ref: '#/components/schemas/NestedUserDetails'
           readOnly: true
+        parent_execution_log_id:
+          type: string
+          format: uuid
+          nullable: true
         score:
           type: number
           format: double
@@ -3517,16 +3548,40 @@ components:
           format: double
           readOnly: true
           nullable: true
+        llm_output:
+          type: string
+          nullable: true
+          readOnly: true
+        variables:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+          readOnly: true
+        evaluation_context:
+          type: object
+          properties:
+            contexts:
+              type: array
+              items:
+                type: string
+            expected_output:
+              type: string
+          nullable: true
+          readOnly: true
       required:
       - cost
       - created_at
+      - evaluation_context
       - id
       - judge
+      - llm_output
       - owner
       - score
       - skill
       - tags
       - validation_result_average
+      - variables
     ID:
       type: object
       properties:
@@ -3673,6 +3728,9 @@ components:
           readOnly: true
         name:
           type: string
+        intent:
+          type: string
+          readOnly: true
         created_at:
           type: string
           format: date-time
@@ -3685,6 +3743,7 @@ components:
       required:
       - created_at
       - id
+      - intent
       - name
       - status
     JudgeRequest:
@@ -3876,7 +3935,7 @@ components:
           readOnly: true
         intent:
           type: string
-          maxLength: 10000
+          maxLength: 100000
         status:
           $ref: '#/components/schemas/StatusEnum'
         validators:
@@ -3930,7 +3989,7 @@ components:
           readOnly: true
         intent:
           type: string
-          maxLength: 10000
+          maxLength: 100000
         status:
           $ref: '#/components/schemas/StatusEnum'
         test_set:
@@ -4014,7 +4073,7 @@ components:
           readOnly: true
         intent:
           type: string
-          maxLength: 10000
+          maxLength: 100000
         status:
           $ref: '#/components/schemas/StatusEnum'
         owner:
@@ -4048,7 +4107,7 @@ components:
         intent:
           type: string
           minLength: 1
-          maxLength: 10000
+          maxLength: 100000
         status:
           $ref: '#/components/schemas/StatusEnum'
         validators:
@@ -4438,7 +4497,7 @@ components:
         intent:
           type: string
           minLength: 1
-          maxLength: 10000
+          maxLength: 100000
         status:
           $ref: '#/components/schemas/StatusEnum'
         validators:

--- a/src/root/execution_logs.py
+++ b/src/root/execution_logs.py
@@ -38,6 +38,7 @@ class ExecutionLogs:
         limit: int = 100,
         search_term: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        include: Optional[List[str]] = None,
         _request_timeout: Optional[int] = None,
         _client: ApiClient,
     ) -> Iterator[ExecutionLogList]:
@@ -48,6 +49,7 @@ class ExecutionLogs:
           limit: Number of entries to iterate through at most.
           search_term: Can be used to limit returned logs. For example, a skill id or name.
           tags: Optional tags to filter the logs by.
+          include: Optional fields to include in the response.
         """
         api_instance = ExecutionLogsApi(_client)
         yield from iterate_cursor_list(
@@ -55,6 +57,7 @@ class ExecutionLogs:
                 api_instance.v1_execution_logs_list,
                 search=search_term,
                 tags=",".join(tags) if tags else None,
+                include=",".join(include) if include else None,
                 _request_timeout=_request_timeout,
             ),
             limit=limit,
@@ -66,6 +69,7 @@ class ExecutionLogs:
         limit: int = 100,
         search_term: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        include: Optional[List[str]] = None,
         _request_timeout: Optional[int] = None,
     ) -> AsyncIterator[AExecutionLogList]:
         """
@@ -75,6 +79,7 @@ class ExecutionLogs:
           limit: Number of entries to iterate through at most.
           search_term: Can be used to limit returned logs. For example, a skill id or name.
           tags: Optional tags to filter the logs by.
+          include: Optional fields to include in the response.
         """
 
         context = self.client_context()
@@ -85,6 +90,7 @@ class ExecutionLogs:
                 api_instance.v1_execution_logs_list,
                 search=search_term,
                 tags=",".join(tags) if tags else None,
+                include=",".join(include) if include else None,
                 _request_timeout=_request_timeout,
             )
 

--- a/src/root/generated/openapi_aclient/api/v1_api.py
+++ b/src/root/generated/openapi_aclient/api/v1_api.py
@@ -7036,6 +7036,12 @@ class V1Api:
     async def v1_execution_logs_list(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7059,6 +7065,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7093,6 +7101,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7118,6 +7127,12 @@ class V1Api:
     async def v1_execution_logs_list_with_http_info(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7141,6 +7156,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7175,6 +7192,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7200,6 +7218,12 @@ class V1Api:
     async def v1_execution_logs_list_without_preload_content(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7223,6 +7247,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7257,6 +7283,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7277,6 +7304,7 @@ class V1Api:
     def _v1_execution_logs_list_serialize(
         self,
         cursor,
+        include,
         ordering,
         page_size,
         search,
@@ -7302,6 +7330,9 @@ class V1Api:
         # process the query parameters
         if cursor is not None:
             _query_params.append(("cursor", cursor))
+
+        if include is not None:
+            _query_params.append(("include", include))
 
         if ordering is not None:
             _query_params.append(("ordering", ordering))
@@ -11652,7 +11683,7 @@ class V1Api:
     @validate_call
     async def v1_skills_evaluator_execute_create(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11668,8 +11699,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11695,7 +11726,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11716,7 +11747,7 @@ class V1Api:
     @validate_call
     async def v1_skills_evaluator_execute_create_with_http_info(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11732,8 +11763,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11759,7 +11790,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11780,7 +11811,7 @@ class V1Api:
     @validate_call
     async def v1_skills_evaluator_execute_create_without_preload_content(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11796,8 +11827,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11823,7 +11854,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11839,7 +11870,7 @@ class V1Api:
 
     def _v1_skills_evaluator_execute_create_serialize(
         self,
-        skill_id,
+        id,
         evaluator_execution_request,
         _request_auth,
         _content_type,
@@ -11858,8 +11889,8 @@ class V1Api:
         _body_params: Optional[bytes] = None
 
         # process the path parameters
-        if skill_id is not None:
-            _path_params["skill_id"] = skill_id
+        if id is not None:
+            _path_params["id"] = id
         # process the query parameters
         # process the header parameters
         # process the form parameters
@@ -11885,7 +11916,7 @@ class V1Api:
 
         return self.api_client.param_serialize(
             method="POST",
-            resource_path="/v1/skills/evaluator/execute/{skill_id}/",
+            resource_path="/v1/skills/evaluator/execute/{id}/",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/src/root/generated/openapi_aclient/models/__init__.py
+++ b/src/root/generated/openapi_aclient/models/__init__.py
@@ -59,10 +59,16 @@ from root.generated.openapi_aclient.models.evaluator_reference_request import Ev
 from root.generated.openapi_aclient.models.evaluator_request import EvaluatorRequest
 from root.generated.openapi_aclient.models.evaluator_result import EvaluatorResult
 from root.generated.openapi_aclient.models.execution_log_details import ExecutionLogDetails
+from root.generated.openapi_aclient.models.execution_log_details_evaluation_context import (
+    ExecutionLogDetailsEvaluationContext,
+)
 from root.generated.openapi_aclient.models.execution_log_details_judge import ExecutionLogDetailsJudge
 from root.generated.openapi_aclient.models.execution_log_details_objective import ExecutionLogDetailsObjective
 from root.generated.openapi_aclient.models.execution_log_details_skill import ExecutionLogDetailsSkill
 from root.generated.openapi_aclient.models.execution_log_list import ExecutionLogList
+from root.generated.openapi_aclient.models.execution_log_list_evaluation_context import (
+    ExecutionLogListEvaluationContext,
+)
 from root.generated.openapi_aclient.models.execution_log_list_skill import ExecutionLogListSkill
 from root.generated.openapi_aclient.models.id import ID
 from root.generated.openapi_aclient.models.input_variable import InputVariable

--- a/src/root/generated/openapi_aclient/models/execution_log_details.py
+++ b/src/root/generated/openapi_aclient/models/execution_log_details.py
@@ -22,6 +22,9 @@ from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self
 
+from root.generated.openapi_aclient.models.execution_log_details_evaluation_context import (
+    ExecutionLogDetailsEvaluationContext,
+)
 from root.generated.openapi_aclient.models.execution_log_details_judge import ExecutionLogDetailsJudge
 from root.generated.openapi_aclient.models.execution_log_details_objective import ExecutionLogDetailsObjective
 from root.generated.openapi_aclient.models.execution_log_details_skill import ExecutionLogDetailsSkill
@@ -38,6 +41,7 @@ class ExecutionLogDetails(BaseModel):
     chat_id: Optional[StrictStr]
     cost: Optional[Union[StrictFloat, StrictInt]]
     created_at: Optional[datetime]
+    evaluation_context: ExecutionLogDetailsEvaluationContext
     id: StrictStr
     judge: Optional[ExecutionLogDetailsJudge]
     justification: StrictStr
@@ -47,16 +51,18 @@ class ExecutionLogDetails(BaseModel):
     model: StrictStr
     objective: ExecutionLogDetailsObjective
     owner: NestedUserDetails
+    parent_execution_log_id: Optional[StrictStr] = None
     rendered_prompt: StrictStr
     score: Optional[Union[StrictFloat, StrictInt]]
     skill: ExecutionLogDetailsSkill
     tags: List[StrictStr]
     validation_results: List[SkillExecutionValidatorResult]
-    variables: Optional[Any]
+    variables: Optional[Dict[str, StrictStr]]
     __properties: ClassVar[List[str]] = [
         "chat_id",
         "cost",
         "created_at",
+        "evaluation_context",
         "id",
         "judge",
         "justification",
@@ -66,6 +72,7 @@ class ExecutionLogDetails(BaseModel):
         "model",
         "objective",
         "owner",
+        "parent_execution_log_id",
         "rendered_prompt",
         "score",
         "skill",
@@ -140,6 +147,9 @@ class ExecutionLogDetails(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of evaluation_context
+        if self.evaluation_context:
+            _dict["evaluation_context"] = self.evaluation_context.to_dict()
         # override the default output from pydantic by calling `to_dict()` of judge
         if self.judge:
             _dict["judge"] = self.judge.to_dict()
@@ -187,6 +197,11 @@ class ExecutionLogDetails(BaseModel):
         if self.model_params is None and "model_params" in self.model_fields_set:
             _dict["model_params"] = None
 
+        # set to None if parent_execution_log_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.parent_execution_log_id is None and "parent_execution_log_id" in self.model_fields_set:
+            _dict["parent_execution_log_id"] = None
+
         # set to None if score (nullable) is None
         # and model_fields_set contains the field
         if self.score is None and "score" in self.model_fields_set:
@@ -213,6 +228,9 @@ class ExecutionLogDetails(BaseModel):
                 "chat_id": obj.get("chat_id"),
                 "cost": obj.get("cost"),
                 "created_at": obj.get("created_at"),
+                "evaluation_context": ExecutionLogDetailsEvaluationContext.from_dict(obj["evaluation_context"])
+                if obj.get("evaluation_context") is not None
+                else None,
                 "id": obj.get("id"),
                 "judge": ExecutionLogDetailsJudge.from_dict(obj["judge"]) if obj.get("judge") is not None else None,
                 "justification": obj.get("justification"),
@@ -226,6 +244,7 @@ class ExecutionLogDetails(BaseModel):
                 if obj.get("objective") is not None
                 else None,
                 "owner": NestedUserDetails.from_dict(obj["owner"]) if obj.get("owner") is not None else None,
+                "parent_execution_log_id": obj.get("parent_execution_log_id"),
                 "rendered_prompt": obj.get("rendered_prompt"),
                 "score": obj.get("score"),
                 "skill": ExecutionLogDetailsSkill.from_dict(obj["skill"]) if obj.get("skill") is not None else None,

--- a/src/root/generated/openapi_aclient/models/execution_log_details_evaluation_context.py
+++ b/src/root/generated/openapi_aclient/models/execution_log_details_evaluation_context.py
@@ -18,23 +18,18 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing_extensions import Annotated, Self
-
-from root.generated.openapi_client.models.objective_validator import ObjectiveValidator
-from root.generated.openapi_client.models.status_enum import StatusEnum
+from pydantic import BaseModel, ConfigDict, StrictStr
+from typing_extensions import Self
 
 
-class NestedObjectiveList(BaseModel):
+class ExecutionLogDetailsEvaluationContext(BaseModel):
     """
-    NestedObjectiveList
+    ExecutionLogDetailsEvaluationContext
     """  # noqa: E501
 
-    id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
-    status: Optional[StatusEnum] = None
-    validators: List[ObjectiveValidator]
-    __properties: ClassVar[List[str]] = ["id", "intent", "status", "validators"]
+    contexts: Optional[List[StrictStr]] = None
+    expected_output: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["contexts", "expected_output"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -53,7 +48,7 @@ class NestedObjectiveList(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a JSON string"""
+        """Create an instance of ExecutionLogDetailsEvaluationContext from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -65,47 +60,24 @@ class NestedObjectiveList(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
-        excluded_fields: Set[str] = set(
-            [
-                "id",
-                "validators",
-            ]
-        )
+        excluded_fields: Set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of each item in validators (list)
-        _items = []
-        if self.validators:
-            for _item in self.validators:
-                if _item:
-                    _items.append(_item.to_dict())
-            _dict["validators"] = _items
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a dict"""
+        """Create an instance of ExecutionLogDetailsEvaluationContext from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "id": obj.get("id"),
-                "intent": obj.get("intent"),
-                "status": obj.get("status"),
-                "validators": [ObjectiveValidator.from_dict(_item) for _item in obj["validators"]]
-                if obj.get("validators") is not None
-                else None,
-            }
-        )
+        _obj = cls.model_validate({"contexts": obj.get("contexts"), "expected_output": obj.get("expected_output")})
         return _obj

--- a/src/root/generated/openapi_aclient/models/execution_log_list.py
+++ b/src/root/generated/openapi_aclient/models/execution_log_list.py
@@ -23,6 +23,9 @@ from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self
 
 from root.generated.openapi_aclient.models.execution_log_details_judge import ExecutionLogDetailsJudge
+from root.generated.openapi_aclient.models.execution_log_list_evaluation_context import (
+    ExecutionLogListEvaluationContext,
+)
 from root.generated.openapi_aclient.models.execution_log_list_skill import ExecutionLogListSkill
 from root.generated.openapi_aclient.models.nested_user_details import NestedUserDetails
 
@@ -37,20 +40,28 @@ class ExecutionLogList(BaseModel):
     id: StrictStr
     judge: Optional[ExecutionLogDetailsJudge]
     owner: NestedUserDetails
+    parent_execution_log_id: Optional[StrictStr] = None
     score: Optional[Union[StrictFloat, StrictInt]]
     skill: ExecutionLogListSkill
     tags: List[StrictStr]
     validation_result_average: Optional[Union[StrictFloat, StrictInt]]
+    llm_output: Optional[StrictStr]
+    variables: Optional[Dict[str, StrictStr]]
+    evaluation_context: Optional[ExecutionLogListEvaluationContext]
     __properties: ClassVar[List[str]] = [
         "cost",
         "created_at",
         "id",
         "judge",
         "owner",
+        "parent_execution_log_id",
         "score",
         "skill",
         "tags",
         "validation_result_average",
+        "llm_output",
+        "variables",
+        "evaluation_context",
     ]
 
     model_config = ConfigDict(
@@ -89,6 +100,8 @@ class ExecutionLogList(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: Set[str] = set(
             [
@@ -99,6 +112,8 @@ class ExecutionLogList(BaseModel):
                 "score",
                 "tags",
                 "validation_result_average",
+                "llm_output",
+                "variables",
             ]
         )
 
@@ -116,6 +131,9 @@ class ExecutionLogList(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of skill
         if self.skill:
             _dict["skill"] = self.skill.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of evaluation_context
+        if self.evaluation_context:
+            _dict["evaluation_context"] = self.evaluation_context.to_dict()
         # set to None if cost (nullable) is None
         # and model_fields_set contains the field
         if self.cost is None and "cost" in self.model_fields_set:
@@ -131,6 +149,11 @@ class ExecutionLogList(BaseModel):
         if self.judge is None and "judge" in self.model_fields_set:
             _dict["judge"] = None
 
+        # set to None if parent_execution_log_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.parent_execution_log_id is None and "parent_execution_log_id" in self.model_fields_set:
+            _dict["parent_execution_log_id"] = None
+
         # set to None if score (nullable) is None
         # and model_fields_set contains the field
         if self.score is None and "score" in self.model_fields_set:
@@ -140,6 +163,21 @@ class ExecutionLogList(BaseModel):
         # and model_fields_set contains the field
         if self.validation_result_average is None and "validation_result_average" in self.model_fields_set:
             _dict["validation_result_average"] = None
+
+        # set to None if llm_output (nullable) is None
+        # and model_fields_set contains the field
+        if self.llm_output is None and "llm_output" in self.model_fields_set:
+            _dict["llm_output"] = None
+
+        # set to None if variables (nullable) is None
+        # and model_fields_set contains the field
+        if self.variables is None and "variables" in self.model_fields_set:
+            _dict["variables"] = None
+
+        # set to None if evaluation_context (nullable) is None
+        # and model_fields_set contains the field
+        if self.evaluation_context is None and "evaluation_context" in self.model_fields_set:
+            _dict["evaluation_context"] = None
 
         return _dict
 
@@ -159,10 +197,16 @@ class ExecutionLogList(BaseModel):
                 "id": obj.get("id"),
                 "judge": ExecutionLogDetailsJudge.from_dict(obj["judge"]) if obj.get("judge") is not None else None,
                 "owner": NestedUserDetails.from_dict(obj["owner"]) if obj.get("owner") is not None else None,
+                "parent_execution_log_id": obj.get("parent_execution_log_id"),
                 "score": obj.get("score"),
                 "skill": ExecutionLogListSkill.from_dict(obj["skill"]) if obj.get("skill") is not None else None,
                 "tags": obj.get("tags"),
                 "validation_result_average": obj.get("validation_result_average"),
+                "llm_output": obj.get("llm_output"),
+                "variables": obj.get("variables"),
+                "evaluation_context": ExecutionLogListEvaluationContext.from_dict(obj["evaluation_context"])
+                if obj.get("evaluation_context") is not None
+                else None,
             }
         )
         return _obj

--- a/src/root/generated/openapi_aclient/models/execution_log_list_evaluation_context.py
+++ b/src/root/generated/openapi_aclient/models/execution_log_list_evaluation_context.py
@@ -18,23 +18,18 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing_extensions import Annotated, Self
-
-from root.generated.openapi_client.models.objective_validator import ObjectiveValidator
-from root.generated.openapi_client.models.status_enum import StatusEnum
+from pydantic import BaseModel, ConfigDict, StrictStr
+from typing_extensions import Self
 
 
-class NestedObjectiveList(BaseModel):
+class ExecutionLogListEvaluationContext(BaseModel):
     """
-    NestedObjectiveList
+    ExecutionLogListEvaluationContext
     """  # noqa: E501
 
-    id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
-    status: Optional[StatusEnum] = None
-    validators: List[ObjectiveValidator]
-    __properties: ClassVar[List[str]] = ["id", "intent", "status", "validators"]
+    contexts: Optional[List[StrictStr]] = None
+    expected_output: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["contexts", "expected_output"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -53,7 +48,7 @@ class NestedObjectiveList(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a JSON string"""
+        """Create an instance of ExecutionLogListEvaluationContext from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -65,47 +60,24 @@ class NestedObjectiveList(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
-        excluded_fields: Set[str] = set(
-            [
-                "id",
-                "validators",
-            ]
-        )
+        excluded_fields: Set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of each item in validators (list)
-        _items = []
-        if self.validators:
-            for _item in self.validators:
-                if _item:
-                    _items.append(_item.to_dict())
-            _dict["validators"] = _items
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a dict"""
+        """Create an instance of ExecutionLogListEvaluationContext from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "id": obj.get("id"),
-                "intent": obj.get("intent"),
-                "status": obj.get("status"),
-                "validators": [ObjectiveValidator.from_dict(_item) for _item in obj["validators"]]
-                if obj.get("validators") is not None
-                else None,
-            }
-        )
+        _obj = cls.model_validate({"contexts": obj.get("contexts"), "expected_output": obj.get("expected_output")})
         return _obj

--- a/src/root/generated/openapi_aclient/models/judge_list.py
+++ b/src/root/generated/openapi_aclient/models/judge_list.py
@@ -32,9 +32,10 @@ class JudgeList(BaseModel):
 
     id: StrictStr
     name: StrictStr
+    intent: StrictStr
     created_at: Optional[datetime]
     status: JudgeStatusEnum
-    __properties: ClassVar[List[str]] = ["id", "name", "created_at", "status"]
+    __properties: ClassVar[List[str]] = ["id", "name", "intent", "created_at", "status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -68,10 +69,12 @@ class JudgeList(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: Set[str] = set(
             [
                 "id",
+                "intent",
                 "created_at",
                 "status",
             ]
@@ -102,6 +105,7 @@ class JudgeList(BaseModel):
             {
                 "id": obj.get("id"),
                 "name": obj.get("name"),
+                "intent": obj.get("intent"),
                 "created_at": obj.get("created_at"),
                 "status": obj.get("status"),
             }

--- a/src/root/generated/openapi_aclient/models/nested_objective_list.py
+++ b/src/root/generated/openapi_aclient/models/nested_objective_list.py
@@ -31,7 +31,7 @@ class NestedObjectiveList(BaseModel):
     """  # noqa: E501
 
     id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     validators: List[ObjectiveValidator]
     __properties: ClassVar[List[str]] = ["id", "intent", "status", "validators"]

--- a/src/root/generated/openapi_aclient/models/objective.py
+++ b/src/root/generated/openapi_aclient/models/objective.py
@@ -33,7 +33,7 @@ class Objective(BaseModel):
     """  # noqa: E501
 
     id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     test_set: Optional[List[List[StrictStr]]] = Field(description="Deprecated: Use test_dataset_id instead.")
     validators: Optional[List[ObjectiveValidator]] = None

--- a/src/root/generated/openapi_aclient/models/objective_list.py
+++ b/src/root/generated/openapi_aclient/models/objective_list.py
@@ -33,7 +33,7 @@ class ObjectiveList(BaseModel):
     """  # noqa: E501
 
     id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     owner: NestedUserDetails
     created_at: Optional[datetime]

--- a/src/root/generated/openapi_aclient/models/objective_request.py
+++ b/src/root/generated/openapi_aclient/models/objective_request.py
@@ -30,7 +30,7 @@ class ObjectiveRequest(BaseModel):
     ObjectiveRequest
     """  # noqa: E501
 
-    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     validators: Optional[List[ObjectiveValidatorRequest]] = None
     force_create: Optional[StrictBool] = Field(

--- a/src/root/generated/openapi_aclient/models/patched_objective_request.py
+++ b/src/root/generated/openapi_aclient/models/patched_objective_request.py
@@ -30,7 +30,7 @@ class PatchedObjectiveRequest(BaseModel):
     PatchedObjectiveRequest
     """  # noqa: E501
 
-    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     validators: Optional[List[ObjectiveValidatorRequest]] = None
     force_create: Optional[StrictBool] = Field(

--- a/src/root/generated/openapi_aclient_README.md
+++ b/src/root/generated/openapi_aclient_README.md
@@ -128,7 +128,7 @@ Class | Method | HTTP request | Description
 *V1Api* | [**v1_skills_calibrate_create2**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_calibrate_create2) | **POST** /v1/skills/calibrate/{id} | 
 *V1Api* | [**v1_skills_create**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_create) | **POST** /v1/skills/ | 
 *V1Api* | [**v1_skills_destroy**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_destroy) | **DELETE** /v1/skills/{id}/ | 
-*V1Api* | [**v1_skills_evaluator_execute_create**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_evaluator_execute_create) | **POST** /v1/skills/evaluator/execute/{skill_id}/ | 
+*V1Api* | [**v1_skills_evaluator_execute_create**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_evaluator_execute_create) | **POST** /v1/skills/evaluator/execute/{id}/ | 
 *V1Api* | [**v1_skills_execute_create**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_execute_create) | **POST** /v1/skills/execute/{id}/ | 
 *V1Api* | [**v1_skills_execute_validators_create**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_execute_validators_create) | **POST** /v1/skills/execute-validators/{id}/ | 
 *V1Api* | [**v1_skills_list**](root/generated/openapi_aclient/docs/V1Api.md#v1_skills_list) | **GET** /v1/skills/ | 
@@ -180,10 +180,12 @@ Class | Method | HTTP request | Description
  - [EvaluatorRequest](root/generated/openapi_aclient/docs/EvaluatorRequest.md)
  - [EvaluatorResult](root/generated/openapi_aclient/docs/EvaluatorResult.md)
  - [ExecutionLogDetails](root/generated/openapi_aclient/docs/ExecutionLogDetails.md)
+ - [ExecutionLogDetailsEvaluationContext](root/generated/openapi_aclient/docs/ExecutionLogDetailsEvaluationContext.md)
  - [ExecutionLogDetailsJudge](root/generated/openapi_aclient/docs/ExecutionLogDetailsJudge.md)
  - [ExecutionLogDetailsObjective](root/generated/openapi_aclient/docs/ExecutionLogDetailsObjective.md)
  - [ExecutionLogDetailsSkill](root/generated/openapi_aclient/docs/ExecutionLogDetailsSkill.md)
  - [ExecutionLogList](root/generated/openapi_aclient/docs/ExecutionLogList.md)
+ - [ExecutionLogListEvaluationContext](root/generated/openapi_aclient/docs/ExecutionLogListEvaluationContext.md)
  - [ExecutionLogListSkill](root/generated/openapi_aclient/docs/ExecutionLogListSkill.md)
  - [ID](root/generated/openapi_aclient/docs/ID.md)
  - [InputVariable](root/generated/openapi_aclient/docs/InputVariable.md)

--- a/src/root/generated/openapi_client/api/v1_api.py
+++ b/src/root/generated/openapi_client/api/v1_api.py
@@ -7036,6 +7036,12 @@ class V1Api:
     def v1_execution_logs_list(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7059,6 +7065,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7093,6 +7101,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7118,6 +7127,12 @@ class V1Api:
     def v1_execution_logs_list_with_http_info(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7141,6 +7156,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7175,6 +7192,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7200,6 +7218,12 @@ class V1Api:
     def v1_execution_logs_list_without_preload_content(
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="The pagination cursor value.")] = None,
+        include: Annotated[
+            Optional[StrictStr],
+            Field(
+                description="Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context"
+            ),
+        ] = None,
         ordering: Annotated[
             Optional[StrictStr], Field(description="Which field to use when ordering the results.")
         ] = None,
@@ -7223,6 +7247,8 @@ class V1Api:
 
         :param cursor: The pagination cursor value.
         :type cursor: str
+        :param include: Comma-separated list of additional fields to include in the response. Supports: llm_output, variables, evaluation_context
+        :type include: str
         :param ordering: Which field to use when ordering the results.
         :type ordering: str
         :param page_size: Number of results to return per page.
@@ -7257,6 +7283,7 @@ class V1Api:
 
         _param = self._v1_execution_logs_list_serialize(
             cursor=cursor,
+            include=include,
             ordering=ordering,
             page_size=page_size,
             search=search,
@@ -7277,6 +7304,7 @@ class V1Api:
     def _v1_execution_logs_list_serialize(
         self,
         cursor,
+        include,
         ordering,
         page_size,
         search,
@@ -7302,6 +7330,9 @@ class V1Api:
         # process the query parameters
         if cursor is not None:
             _query_params.append(("cursor", cursor))
+
+        if include is not None:
+            _query_params.append(("include", include))
 
         if ordering is not None:
             _query_params.append(("ordering", ordering))
@@ -11652,7 +11683,7 @@ class V1Api:
     @validate_call
     def v1_skills_evaluator_execute_create(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11668,8 +11699,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11695,7 +11726,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11716,7 +11747,7 @@ class V1Api:
     @validate_call
     def v1_skills_evaluator_execute_create_with_http_info(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11732,8 +11763,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11759,7 +11790,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11780,7 +11811,7 @@ class V1Api:
     @validate_call
     def v1_skills_evaluator_execute_create_without_preload_content(
         self,
-        skill_id: StrictStr,
+        id: StrictStr,
         evaluator_execution_request: Optional[EvaluatorExecutionRequest] = None,
         _request_timeout: Union[
             None,
@@ -11796,8 +11827,8 @@ class V1Api:
 
         Execute an evaluator
 
-        :param skill_id: (required)
-        :type skill_id: str
+        :param id: (required)
+        :type id: str
         :param evaluator_execution_request:
         :type evaluator_execution_request: EvaluatorExecutionRequest
         :param _request_timeout: timeout setting for this request. If one
@@ -11823,7 +11854,7 @@ class V1Api:
         """  # noqa: E501
 
         _param = self._v1_skills_evaluator_execute_create_serialize(
-            skill_id=skill_id,
+            id=id,
             evaluator_execution_request=evaluator_execution_request,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -11839,7 +11870,7 @@ class V1Api:
 
     def _v1_skills_evaluator_execute_create_serialize(
         self,
-        skill_id,
+        id,
         evaluator_execution_request,
         _request_auth,
         _content_type,
@@ -11858,8 +11889,8 @@ class V1Api:
         _body_params: Optional[bytes] = None
 
         # process the path parameters
-        if skill_id is not None:
-            _path_params["skill_id"] = skill_id
+        if id is not None:
+            _path_params["id"] = id
         # process the query parameters
         # process the header parameters
         # process the form parameters
@@ -11885,7 +11916,7 @@ class V1Api:
 
         return self.api_client.param_serialize(
             method="POST",
-            resource_path="/v1/skills/evaluator/execute/{skill_id}/",
+            resource_path="/v1/skills/evaluator/execute/{id}/",
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/src/root/generated/openapi_client/models/__init__.py
+++ b/src/root/generated/openapi_client/models/__init__.py
@@ -59,10 +59,14 @@ from root.generated.openapi_client.models.evaluator_reference_request import Eva
 from root.generated.openapi_client.models.evaluator_request import EvaluatorRequest
 from root.generated.openapi_client.models.evaluator_result import EvaluatorResult
 from root.generated.openapi_client.models.execution_log_details import ExecutionLogDetails
+from root.generated.openapi_client.models.execution_log_details_evaluation_context import (
+    ExecutionLogDetailsEvaluationContext,
+)
 from root.generated.openapi_client.models.execution_log_details_judge import ExecutionLogDetailsJudge
 from root.generated.openapi_client.models.execution_log_details_objective import ExecutionLogDetailsObjective
 from root.generated.openapi_client.models.execution_log_details_skill import ExecutionLogDetailsSkill
 from root.generated.openapi_client.models.execution_log_list import ExecutionLogList
+from root.generated.openapi_client.models.execution_log_list_evaluation_context import ExecutionLogListEvaluationContext
 from root.generated.openapi_client.models.execution_log_list_skill import ExecutionLogListSkill
 from root.generated.openapi_client.models.id import ID
 from root.generated.openapi_client.models.input_variable import InputVariable

--- a/src/root/generated/openapi_client/models/execution_log_details.py
+++ b/src/root/generated/openapi_client/models/execution_log_details.py
@@ -22,6 +22,9 @@ from typing import Any, ClassVar, Dict, List, Optional, Set, Union
 from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self
 
+from root.generated.openapi_client.models.execution_log_details_evaluation_context import (
+    ExecutionLogDetailsEvaluationContext,
+)
 from root.generated.openapi_client.models.execution_log_details_judge import ExecutionLogDetailsJudge
 from root.generated.openapi_client.models.execution_log_details_objective import ExecutionLogDetailsObjective
 from root.generated.openapi_client.models.execution_log_details_skill import ExecutionLogDetailsSkill
@@ -38,6 +41,7 @@ class ExecutionLogDetails(BaseModel):
     chat_id: Optional[StrictStr]
     cost: Optional[Union[StrictFloat, StrictInt]]
     created_at: Optional[datetime]
+    evaluation_context: ExecutionLogDetailsEvaluationContext
     id: StrictStr
     judge: Optional[ExecutionLogDetailsJudge]
     justification: StrictStr
@@ -47,16 +51,18 @@ class ExecutionLogDetails(BaseModel):
     model: StrictStr
     objective: ExecutionLogDetailsObjective
     owner: NestedUserDetails
+    parent_execution_log_id: Optional[StrictStr] = None
     rendered_prompt: StrictStr
     score: Optional[Union[StrictFloat, StrictInt]]
     skill: ExecutionLogDetailsSkill
     tags: List[StrictStr]
     validation_results: List[SkillExecutionValidatorResult]
-    variables: Optional[Any]
+    variables: Optional[Dict[str, StrictStr]]
     __properties: ClassVar[List[str]] = [
         "chat_id",
         "cost",
         "created_at",
+        "evaluation_context",
         "id",
         "judge",
         "justification",
@@ -66,6 +72,7 @@ class ExecutionLogDetails(BaseModel):
         "model",
         "objective",
         "owner",
+        "parent_execution_log_id",
         "rendered_prompt",
         "score",
         "skill",
@@ -140,6 +147,9 @@ class ExecutionLogDetails(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of evaluation_context
+        if self.evaluation_context:
+            _dict["evaluation_context"] = self.evaluation_context.to_dict()
         # override the default output from pydantic by calling `to_dict()` of judge
         if self.judge:
             _dict["judge"] = self.judge.to_dict()
@@ -187,6 +197,11 @@ class ExecutionLogDetails(BaseModel):
         if self.model_params is None and "model_params" in self.model_fields_set:
             _dict["model_params"] = None
 
+        # set to None if parent_execution_log_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.parent_execution_log_id is None and "parent_execution_log_id" in self.model_fields_set:
+            _dict["parent_execution_log_id"] = None
+
         # set to None if score (nullable) is None
         # and model_fields_set contains the field
         if self.score is None and "score" in self.model_fields_set:
@@ -213,6 +228,9 @@ class ExecutionLogDetails(BaseModel):
                 "chat_id": obj.get("chat_id"),
                 "cost": obj.get("cost"),
                 "created_at": obj.get("created_at"),
+                "evaluation_context": ExecutionLogDetailsEvaluationContext.from_dict(obj["evaluation_context"])
+                if obj.get("evaluation_context") is not None
+                else None,
                 "id": obj.get("id"),
                 "judge": ExecutionLogDetailsJudge.from_dict(obj["judge"]) if obj.get("judge") is not None else None,
                 "justification": obj.get("justification"),
@@ -226,6 +244,7 @@ class ExecutionLogDetails(BaseModel):
                 if obj.get("objective") is not None
                 else None,
                 "owner": NestedUserDetails.from_dict(obj["owner"]) if obj.get("owner") is not None else None,
+                "parent_execution_log_id": obj.get("parent_execution_log_id"),
                 "rendered_prompt": obj.get("rendered_prompt"),
                 "score": obj.get("score"),
                 "skill": ExecutionLogDetailsSkill.from_dict(obj["skill"]) if obj.get("skill") is not None else None,

--- a/src/root/generated/openapi_client/models/execution_log_details_evaluation_context.py
+++ b/src/root/generated/openapi_client/models/execution_log_details_evaluation_context.py
@@ -18,23 +18,18 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing_extensions import Annotated, Self
-
-from root.generated.openapi_client.models.objective_validator import ObjectiveValidator
-from root.generated.openapi_client.models.status_enum import StatusEnum
+from pydantic import BaseModel, ConfigDict, StrictStr
+from typing_extensions import Self
 
 
-class NestedObjectiveList(BaseModel):
+class ExecutionLogDetailsEvaluationContext(BaseModel):
     """
-    NestedObjectiveList
+    ExecutionLogDetailsEvaluationContext
     """  # noqa: E501
 
-    id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
-    status: Optional[StatusEnum] = None
-    validators: List[ObjectiveValidator]
-    __properties: ClassVar[List[str]] = ["id", "intent", "status", "validators"]
+    contexts: Optional[List[StrictStr]] = None
+    expected_output: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["contexts", "expected_output"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -53,7 +48,7 @@ class NestedObjectiveList(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a JSON string"""
+        """Create an instance of ExecutionLogDetailsEvaluationContext from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -65,47 +60,24 @@ class NestedObjectiveList(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
-        excluded_fields: Set[str] = set(
-            [
-                "id",
-                "validators",
-            ]
-        )
+        excluded_fields: Set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of each item in validators (list)
-        _items = []
-        if self.validators:
-            for _item in self.validators:
-                if _item:
-                    _items.append(_item.to_dict())
-            _dict["validators"] = _items
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a dict"""
+        """Create an instance of ExecutionLogDetailsEvaluationContext from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "id": obj.get("id"),
-                "intent": obj.get("intent"),
-                "status": obj.get("status"),
-                "validators": [ObjectiveValidator.from_dict(_item) for _item in obj["validators"]]
-                if obj.get("validators") is not None
-                else None,
-            }
-        )
+        _obj = cls.model_validate({"contexts": obj.get("contexts"), "expected_output": obj.get("expected_output")})
         return _obj

--- a/src/root/generated/openapi_client/models/execution_log_list.py
+++ b/src/root/generated/openapi_client/models/execution_log_list.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict, StrictFloat, StrictInt, StrictStr
 from typing_extensions import Self
 
 from root.generated.openapi_client.models.execution_log_details_judge import ExecutionLogDetailsJudge
+from root.generated.openapi_client.models.execution_log_list_evaluation_context import ExecutionLogListEvaluationContext
 from root.generated.openapi_client.models.execution_log_list_skill import ExecutionLogListSkill
 from root.generated.openapi_client.models.nested_user_details import NestedUserDetails
 
@@ -37,20 +38,28 @@ class ExecutionLogList(BaseModel):
     id: StrictStr
     judge: Optional[ExecutionLogDetailsJudge]
     owner: NestedUserDetails
+    parent_execution_log_id: Optional[StrictStr] = None
     score: Optional[Union[StrictFloat, StrictInt]]
     skill: ExecutionLogListSkill
     tags: List[StrictStr]
     validation_result_average: Optional[Union[StrictFloat, StrictInt]]
+    llm_output: Optional[StrictStr]
+    variables: Optional[Dict[str, StrictStr]]
+    evaluation_context: Optional[ExecutionLogListEvaluationContext]
     __properties: ClassVar[List[str]] = [
         "cost",
         "created_at",
         "id",
         "judge",
         "owner",
+        "parent_execution_log_id",
         "score",
         "skill",
         "tags",
         "validation_result_average",
+        "llm_output",
+        "variables",
+        "evaluation_context",
     ]
 
     model_config = ConfigDict(
@@ -89,6 +98,8 @@ class ExecutionLogList(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: Set[str] = set(
             [
@@ -99,6 +110,8 @@ class ExecutionLogList(BaseModel):
                 "score",
                 "tags",
                 "validation_result_average",
+                "llm_output",
+                "variables",
             ]
         )
 
@@ -116,6 +129,9 @@ class ExecutionLogList(BaseModel):
         # override the default output from pydantic by calling `to_dict()` of skill
         if self.skill:
             _dict["skill"] = self.skill.to_dict()
+        # override the default output from pydantic by calling `to_dict()` of evaluation_context
+        if self.evaluation_context:
+            _dict["evaluation_context"] = self.evaluation_context.to_dict()
         # set to None if cost (nullable) is None
         # and model_fields_set contains the field
         if self.cost is None and "cost" in self.model_fields_set:
@@ -131,6 +147,11 @@ class ExecutionLogList(BaseModel):
         if self.judge is None and "judge" in self.model_fields_set:
             _dict["judge"] = None
 
+        # set to None if parent_execution_log_id (nullable) is None
+        # and model_fields_set contains the field
+        if self.parent_execution_log_id is None and "parent_execution_log_id" in self.model_fields_set:
+            _dict["parent_execution_log_id"] = None
+
         # set to None if score (nullable) is None
         # and model_fields_set contains the field
         if self.score is None and "score" in self.model_fields_set:
@@ -140,6 +161,21 @@ class ExecutionLogList(BaseModel):
         # and model_fields_set contains the field
         if self.validation_result_average is None and "validation_result_average" in self.model_fields_set:
             _dict["validation_result_average"] = None
+
+        # set to None if llm_output (nullable) is None
+        # and model_fields_set contains the field
+        if self.llm_output is None and "llm_output" in self.model_fields_set:
+            _dict["llm_output"] = None
+
+        # set to None if variables (nullable) is None
+        # and model_fields_set contains the field
+        if self.variables is None and "variables" in self.model_fields_set:
+            _dict["variables"] = None
+
+        # set to None if evaluation_context (nullable) is None
+        # and model_fields_set contains the field
+        if self.evaluation_context is None and "evaluation_context" in self.model_fields_set:
+            _dict["evaluation_context"] = None
 
         return _dict
 
@@ -159,10 +195,16 @@ class ExecutionLogList(BaseModel):
                 "id": obj.get("id"),
                 "judge": ExecutionLogDetailsJudge.from_dict(obj["judge"]) if obj.get("judge") is not None else None,
                 "owner": NestedUserDetails.from_dict(obj["owner"]) if obj.get("owner") is not None else None,
+                "parent_execution_log_id": obj.get("parent_execution_log_id"),
                 "score": obj.get("score"),
                 "skill": ExecutionLogListSkill.from_dict(obj["skill"]) if obj.get("skill") is not None else None,
                 "tags": obj.get("tags"),
                 "validation_result_average": obj.get("validation_result_average"),
+                "llm_output": obj.get("llm_output"),
+                "variables": obj.get("variables"),
+                "evaluation_context": ExecutionLogListEvaluationContext.from_dict(obj["evaluation_context"])
+                if obj.get("evaluation_context") is not None
+                else None,
             }
         )
         return _obj

--- a/src/root/generated/openapi_client/models/execution_log_list_evaluation_context.py
+++ b/src/root/generated/openapi_client/models/execution_log_list_evaluation_context.py
@@ -18,23 +18,18 @@ import pprint
 import re  # noqa: F401
 from typing import Any, ClassVar, Dict, List, Optional, Set
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing_extensions import Annotated, Self
-
-from root.generated.openapi_client.models.objective_validator import ObjectiveValidator
-from root.generated.openapi_client.models.status_enum import StatusEnum
+from pydantic import BaseModel, ConfigDict, StrictStr
+from typing_extensions import Self
 
 
-class NestedObjectiveList(BaseModel):
+class ExecutionLogListEvaluationContext(BaseModel):
     """
-    NestedObjectiveList
+    ExecutionLogListEvaluationContext
     """  # noqa: E501
 
-    id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
-    status: Optional[StatusEnum] = None
-    validators: List[ObjectiveValidator]
-    __properties: ClassVar[List[str]] = ["id", "intent", "status", "validators"]
+    contexts: Optional[List[StrictStr]] = None
+    expected_output: Optional[StrictStr] = None
+    __properties: ClassVar[List[str]] = ["contexts", "expected_output"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -53,7 +48,7 @@ class NestedObjectiveList(BaseModel):
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a JSON string"""
+        """Create an instance of ExecutionLogListEvaluationContext from a JSON string"""
         return cls.from_dict(json.loads(json_str))
 
     def to_dict(self) -> Dict[str, Any]:
@@ -65,47 +60,24 @@ class NestedObjectiveList(BaseModel):
         * `None` is only added to the output dict for nullable fields that
           were set at model initialization. Other fields with value `None`
           are ignored.
-        * OpenAPI `readOnly` fields are excluded.
-        * OpenAPI `readOnly` fields are excluded.
         """
-        excluded_fields: Set[str] = set(
-            [
-                "id",
-                "validators",
-            ]
-        )
+        excluded_fields: Set[str] = set([])
 
         _dict = self.model_dump(
             by_alias=True,
             exclude=excluded_fields,
             exclude_none=True,
         )
-        # override the default output from pydantic by calling `to_dict()` of each item in validators (list)
-        _items = []
-        if self.validators:
-            for _item in self.validators:
-                if _item:
-                    _items.append(_item.to_dict())
-            _dict["validators"] = _items
         return _dict
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
-        """Create an instance of NestedObjectiveList from a dict"""
+        """Create an instance of ExecutionLogListEvaluationContext from a dict"""
         if obj is None:
             return None
 
         if not isinstance(obj, dict):
             return cls.model_validate(obj)
 
-        _obj = cls.model_validate(
-            {
-                "id": obj.get("id"),
-                "intent": obj.get("intent"),
-                "status": obj.get("status"),
-                "validators": [ObjectiveValidator.from_dict(_item) for _item in obj["validators"]]
-                if obj.get("validators") is not None
-                else None,
-            }
-        )
+        _obj = cls.model_validate({"contexts": obj.get("contexts"), "expected_output": obj.get("expected_output")})
         return _obj

--- a/src/root/generated/openapi_client/models/judge_list.py
+++ b/src/root/generated/openapi_client/models/judge_list.py
@@ -32,9 +32,10 @@ class JudgeList(BaseModel):
 
     id: StrictStr
     name: StrictStr
+    intent: StrictStr
     created_at: Optional[datetime]
     status: JudgeStatusEnum
-    __properties: ClassVar[List[str]] = ["id", "name", "created_at", "status"]
+    __properties: ClassVar[List[str]] = ["id", "name", "intent", "created_at", "status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -68,10 +69,12 @@ class JudgeList(BaseModel):
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
         * OpenAPI `readOnly` fields are excluded.
+        * OpenAPI `readOnly` fields are excluded.
         """
         excluded_fields: Set[str] = set(
             [
                 "id",
+                "intent",
                 "created_at",
                 "status",
             ]
@@ -102,6 +105,7 @@ class JudgeList(BaseModel):
             {
                 "id": obj.get("id"),
                 "name": obj.get("name"),
+                "intent": obj.get("intent"),
                 "created_at": obj.get("created_at"),
                 "status": obj.get("status"),
             }

--- a/src/root/generated/openapi_client/models/objective.py
+++ b/src/root/generated/openapi_client/models/objective.py
@@ -33,7 +33,7 @@ class Objective(BaseModel):
     """  # noqa: E501
 
     id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     test_set: Optional[List[List[StrictStr]]] = Field(description="Deprecated: Use test_dataset_id instead.")
     validators: Optional[List[ObjectiveValidator]] = None

--- a/src/root/generated/openapi_client/models/objective_list.py
+++ b/src/root/generated/openapi_client/models/objective_list.py
@@ -33,7 +33,7 @@ class ObjectiveList(BaseModel):
     """  # noqa: E501
 
     id: StrictStr
-    intent: Optional[Annotated[str, Field(strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     owner: NestedUserDetails
     created_at: Optional[datetime]

--- a/src/root/generated/openapi_client/models/objective_request.py
+++ b/src/root/generated/openapi_client/models/objective_request.py
@@ -30,7 +30,7 @@ class ObjectiveRequest(BaseModel):
     ObjectiveRequest
     """  # noqa: E501
 
-    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     validators: Optional[List[ObjectiveValidatorRequest]] = None
     force_create: Optional[StrictBool] = Field(

--- a/src/root/generated/openapi_client/models/patched_objective_request.py
+++ b/src/root/generated/openapi_client/models/patched_objective_request.py
@@ -30,7 +30,7 @@ class PatchedObjectiveRequest(BaseModel):
     PatchedObjectiveRequest
     """  # noqa: E501
 
-    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=10000)]] = None
+    intent: Optional[Annotated[str, Field(min_length=1, strict=True, max_length=100000)]] = None
     status: Optional[StatusEnum] = None
     validators: Optional[List[ObjectiveValidatorRequest]] = None
     force_create: Optional[StrictBool] = Field(

--- a/src/root/generated/openapi_client_README.md
+++ b/src/root/generated/openapi_client_README.md
@@ -127,7 +127,7 @@ Class | Method | HTTP request | Description
 *V1Api* | [**v1_skills_calibrate_create2**](root/generated/openapi_client/docs/V1Api.md#v1_skills_calibrate_create2) | **POST** /v1/skills/calibrate/{id} | 
 *V1Api* | [**v1_skills_create**](root/generated/openapi_client/docs/V1Api.md#v1_skills_create) | **POST** /v1/skills/ | 
 *V1Api* | [**v1_skills_destroy**](root/generated/openapi_client/docs/V1Api.md#v1_skills_destroy) | **DELETE** /v1/skills/{id}/ | 
-*V1Api* | [**v1_skills_evaluator_execute_create**](root/generated/openapi_client/docs/V1Api.md#v1_skills_evaluator_execute_create) | **POST** /v1/skills/evaluator/execute/{skill_id}/ | 
+*V1Api* | [**v1_skills_evaluator_execute_create**](root/generated/openapi_client/docs/V1Api.md#v1_skills_evaluator_execute_create) | **POST** /v1/skills/evaluator/execute/{id}/ | 
 *V1Api* | [**v1_skills_execute_create**](root/generated/openapi_client/docs/V1Api.md#v1_skills_execute_create) | **POST** /v1/skills/execute/{id}/ | 
 *V1Api* | [**v1_skills_execute_validators_create**](root/generated/openapi_client/docs/V1Api.md#v1_skills_execute_validators_create) | **POST** /v1/skills/execute-validators/{id}/ | 
 *V1Api* | [**v1_skills_list**](root/generated/openapi_client/docs/V1Api.md#v1_skills_list) | **GET** /v1/skills/ | 
@@ -179,10 +179,12 @@ Class | Method | HTTP request | Description
  - [EvaluatorRequest](root/generated/openapi_client/docs/EvaluatorRequest.md)
  - [EvaluatorResult](root/generated/openapi_client/docs/EvaluatorResult.md)
  - [ExecutionLogDetails](root/generated/openapi_client/docs/ExecutionLogDetails.md)
+ - [ExecutionLogDetailsEvaluationContext](root/generated/openapi_client/docs/ExecutionLogDetailsEvaluationContext.md)
  - [ExecutionLogDetailsJudge](root/generated/openapi_client/docs/ExecutionLogDetailsJudge.md)
  - [ExecutionLogDetailsObjective](root/generated/openapi_client/docs/ExecutionLogDetailsObjective.md)
  - [ExecutionLogDetailsSkill](root/generated/openapi_client/docs/ExecutionLogDetailsSkill.md)
  - [ExecutionLogList](root/generated/openapi_client/docs/ExecutionLogList.md)
+ - [ExecutionLogListEvaluationContext](root/generated/openapi_client/docs/ExecutionLogListEvaluationContext.md)
  - [ExecutionLogListSkill](root/generated/openapi_client/docs/ExecutionLogListSkill.md)
  - [ID](root/generated/openapi_client/docs/ID.md)
  - [InputVariable](root/generated/openapi_client/docs/InputVariable.md)

--- a/src/root/skills.py
+++ b/src/root/skills.py
@@ -505,7 +505,7 @@ class Evaluator(OpenAPISkill):
             tags=tags,
         )
         return api_instance.v1_skills_evaluator_execute_create(
-            skill_id=self.id,
+            id=self.id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )
@@ -574,7 +574,7 @@ class AEvaluator(AOpenAPISkill):
             tags=tags,
         )
         return await api_instance.v1_skills_evaluator_execute_create(
-            skill_id=self.id,
+            id=self.id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )
@@ -749,7 +749,7 @@ class PresetEvaluatorRunner:
             tags=tags,
         )
         return api_instance.v1_skills_evaluator_execute_create(
-            skill_id=self.skill_id,
+            id=self.skill_id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )
@@ -814,7 +814,7 @@ class APresetEvaluatorRunner:
             tags=tags,
         )
         return await api_instance.v1_skills_evaluator_execute_create(
-            skill_id=self.skill_id,
+            id=self.skill_id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )
@@ -1676,7 +1676,7 @@ class Evaluators:
             tags=tags,
         )
         return api_instance.v1_skills_evaluator_execute_create(
-            skill_id=evaluator_id,
+            id=evaluator_id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )
@@ -1729,7 +1729,7 @@ class Evaluators:
             tags=tags,
         )
         return await api_instance.v1_skills_evaluator_execute_create(
-            skill_id=evaluator_id,
+            id=evaluator_id,
             evaluator_execution_request=evaluator_execution_request,
             _request_timeout=_request_timeout,
         )


### PR DESCRIPTION
The execution log listing endpoint has set fields that are not included by default. Introduces the parameter to include them in the response.