### PR TITLE
chore: generate documentation to push to gh-pages

### DIFF
--- a/.github/workflows/generate_documentation.yaml
+++ b/.github/workflows/generate_documentation.yaml
@@ -1,0 +1,36 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main  
+
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write 
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Setup
+        run: make .venv
+
+      - name: Generate docs
+        run: make rtd-html
+
+      # Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages 🚀
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "root-signals Python SDK"
-copyright = "2024, Root Signals Ltd"  # noqa: A001
+copyright = "2025, Root Signals Ltd"  # noqa: A001
 author = "Root Signals"
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Introduced automated deployment of documentation to GitHub Pages on every push to the main branch and via manual trigger.
	- Updated the copyright year in the documentation to 2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->