### PR TITLE
Add redirects from /en paths to /

### DIFF
--- a/docs/_extra/en/index.html
+++ b/docs/_extra/en/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=../">
+    <script>
+        window.location.href = '../';
+    </script>
+</head>
+<body>
+    <p>If you are not redirected automatically, <a href="../">click here</a>.</p>
+</body>
+</html> 

--- a/docs/_extra/en/latest/index.html
+++ b/docs/_extra/en/latest/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="refresh" content="0; url=../../">
+    <script>
+        window.location.href = '../../';
+    </script>
+</head>
+<body>
+    <p>If you are not redirected automatically, <a href="../../">click here</a>.</p>
+</body>
+</html> 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # html_theme = "alabaster"
 html_theme = "furo"
-# html_static_path = ["_static"]
+html_extra_path = ["_extra"]
 
 autodoc_typehints = "both"  # default is 'signature' (not in description)
 


### PR DESCRIPTION
Backwards compatibility for old links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added redirect pages to the documentation that automatically navigate users to the appropriate parent directories, with fallback links for manual navigation.
  - Updated documentation configuration to include additional static resources from a new directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->